### PR TITLE
Add settings button to add new task rows

### DIFF
--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { getProgress, updateProgress } from "@/lib/database"
+import { getProgress, updateProgress, createProgress } from "@/lib/database"
 
 export async function GET() {
   try {
@@ -19,5 +19,16 @@ export async function PUT(request: Request) {
   } catch (error) {
     console.error("Error updating progress:", error)
     return NextResponse.json({ error: "Failed to update progress" }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { subjectName, tableType, totalPdfs } = await request.json()
+    await createProgress(subjectName, tableType, totalPdfs)
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Error creating progress:", error)
+    return NextResponse.json({ error: "Failed to create progress" }, { status: 500 })
   }
 }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -67,10 +67,21 @@ export async function updateProgress(
   totalPdfs: number,
 ) {
   await sql`
-    UPDATE progress 
-    SET current_progress = ${currentProgress}, 
+    UPDATE progress
+    SET current_progress = ${currentProgress},
         total_pdfs = ${totalPdfs},
         updated_at = CURRENT_TIMESTAMP
     WHERE subject_name = ${subjectName} AND table_type = ${tableType}
+  `
+}
+
+export async function createProgress(
+  subjectName: string,
+  tableType: "theory" | "practice",
+  totalPdfs: number,
+) {
+  await sql`
+    INSERT INTO progress (subject_name, table_type, current_progress, total_pdfs)
+    VALUES (${subjectName}, ${tableType}, 0, ${totalPdfs})
   `
 }


### PR DESCRIPTION
## Summary
- add settings gear to add new task rows in progress tracker
- persist new tasks via POST /api/progress and createProgress DB helper

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1 - requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a60462253c833082f71f628567e652