### PR TITLE
Add Important tasks tracking with database and UI support

### DIFF
--- a/app/api/important/route.ts
+++ b/app/api/important/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server"
+import {
+  getImportantTasks,
+  createImportantTask,
+  updateImportantTask,
+  deleteImportantTask,
+} from "@/lib/database"
+
+export const dynamic = "force-dynamic"
+
+export async function GET() {
+  try {
+    const tasks = await getImportantTasks()
+    return NextResponse.json(tasks)
+  } catch (error) {
+    console.error("Error fetching important tasks:", error)
+    return NextResponse.json({ error: "Failed to fetch" }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const data = await request.json()
+    const task = await createImportantTask(data)
+    return NextResponse.json(task, { status: 201 })
+  } catch (error) {
+    console.error("Error creating important task:", error)
+    return NextResponse.json({ error: "Failed to create" }, { status: 500 })
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const { id, ...data } = await request.json()
+    const task = await updateImportantTask(id, data)
+    return NextResponse.json(task)
+  } catch (error) {
+    console.error("Error updating important task:", error)
+    return NextResponse.json({ error: "Failed to update" }, { status: 500 })
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const { id } = await request.json()
+    await deleteImportantTask(id)
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Error deleting important task:", error)
+    return NextResponse.json({ error: "Failed to delete" }, { status: 500 })
+  }
+}

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -2,6 +2,20 @@ import { neon } from "@neondatabase/serverless"
 
 const sql = neon(process.env.DATABASE_URL!)
 
+async function ensureImportantTasksTable() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS important_tasks (
+      id SERIAL PRIMARY KEY,
+      text TEXT NOT NULL,
+      numerator INTEGER DEFAULT 0,
+      denominator INTEGER DEFAULT 1,
+      days_remaining INTEGER DEFAULT 0,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+  `
+}
+
 export interface Subject {
   id: number
   name: string
@@ -18,6 +32,16 @@ export interface Progress {
   table_type: "theory" | "practice"
   current_progress: number
   total_pdfs: number
+  created_at: string
+  updated_at: string
+}
+
+export interface ImportantTask {
+  id: number
+  text: string
+  numerator: number
+  denominator: number
+  days_remaining: number
   created_at: string
   updated_at: string
 }
@@ -67,10 +91,73 @@ export async function updateProgress(
   totalPdfs: number,
 ) {
   await sql`
-    UPDATE progress 
-    SET current_progress = ${currentProgress}, 
+    UPDATE progress
+    SET current_progress = ${currentProgress},
         total_pdfs = ${totalPdfs},
         updated_at = CURRENT_TIMESTAMP
     WHERE subject_name = ${subjectName} AND table_type = ${tableType}
   `
+}
+
+export async function getImportantTasks(): Promise<ImportantTask[]> {
+  await ensureImportantTasksTable()
+  const result = await sql`SELECT * FROM important_tasks ORDER BY id`
+  return result as ImportantTask[]
+}
+
+export async function createImportantTask(
+  data: Partial<ImportantTask>,
+): Promise<ImportantTask> {
+  await ensureImportantTasksTable()
+  const result = await sql<ImportantTask[]>`
+    INSERT INTO important_tasks (text, numerator, denominator, days_remaining)
+    VALUES (
+      ${data.text ?? ""},
+      ${data.numerator ?? 0},
+      ${data.denominator ?? 1},
+      ${data.days_remaining ?? 0}
+    )
+    RETURNING *
+  `
+  return result[0]
+}
+
+export async function updateImportantTask(
+  id: number,
+  data: Partial<ImportantTask>,
+): Promise<ImportantTask | null> {
+  const updates = []
+  const values: any[] = []
+  let paramIndex = 1
+
+  if (data.text !== undefined) {
+    updates.push(`text = $${paramIndex++}`)
+    values.push(data.text)
+  }
+  if (data.numerator !== undefined) {
+    updates.push(`numerator = $${paramIndex++}`)
+    values.push(data.numerator)
+  }
+  if (data.denominator !== undefined) {
+    updates.push(`denominator = $${paramIndex++}`)
+    values.push(data.denominator)
+  }
+  if (data.days_remaining !== undefined) {
+    updates.push(`days_remaining = $${paramIndex++}`)
+    values.push(data.days_remaining)
+  }
+
+  if (updates.length === 0) return null
+
+  const query = `UPDATE important_tasks SET ${updates.join(", ")}, updated_at = CURRENT_TIMESTAMP WHERE id = $${paramIndex} RETURNING *`
+  values.push(id)
+
+  await ensureImportantTasksTable()
+  const result = await sql<ImportantTask[]>(query, values)
+  return result[0] ?? null
+}
+
+export async function deleteImportantTask(id: number): Promise<void> {
+  await ensureImportantTasksTable()
+  await sql`DELETE FROM important_tasks WHERE id = ${id}`
 }

--- a/scripts/04-create-important-tasks-table.sql
+++ b/scripts/04-create-important-tasks-table.sql
@@ -1,0 +1,10 @@
+-- Creating table for important tasks
+CREATE TABLE IF NOT EXISTS important_tasks (
+  id SERIAL PRIMARY KEY,
+  text TEXT NOT NULL,
+  numerator INTEGER DEFAULT 0,
+  denominator INTEGER DEFAULT 1,
+  days_remaining INTEGER DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- Add new `important_tasks` database helpers and API route for CRUD operations
- Extend progress tracker with left-side button and full UI to manage "Importantes" tasks including days editor
- Create `important_tasks` table automatically and add SQL migration script
- Ensure important task API returns created/updated rows and disable route caching
- Avoid cached fetches and update UI after creating new important tasks

## Testing
- `pnpm lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4152ea4883308a6016f552699569