### PR TITLE
Add Important tasks tracking with database and UI support

### DIFF
--- a/app/api/important/route.ts
+++ b/app/api/important/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server"
+import {
+  getImportantTasks,
+  createImportantTask,
+  updateImportantTask,
+  deleteImportantTask,
+} from "@/lib/database"
+
+export const dynamic = "force-dynamic"
+
+export async function GET() {
+  try {
+    const tasks = await getImportantTasks()
+    return NextResponse.json(tasks)
+  } catch (error) {
+    console.error("Error fetching important tasks:", error)
+    return NextResponse.json({ error: "Failed to fetch" }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const data = await request.json()
+    const task = await createImportantTask(data)
+    return NextResponse.json(task, { status: 201 })
+  } catch (error) {
+    console.error("Error creating important task:", error)
+    return NextResponse.json({ error: "Failed to create" }, { status: 500 })
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const { id, ...data } = await request.json()
+    const task = await updateImportantTask(id, data)
+    return NextResponse.json(task)
+  } catch (error) {
+    console.error("Error updating important task:", error)
+    return NextResponse.json({ error: "Failed to update" }, { status: 500 })
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const { id } = await request.json()
+    await deleteImportantTask(id)
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Error deleting important task:", error)
+    return NextResponse.json({ error: "Failed to delete" }, { status: 500 })
+  }
+}

--- a/components/progress-tracker.tsx
+++ b/components/progress-tracker.tsx
@@ -3,13 +3,14 @@
 import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { ChevronLeft, ChevronRight, Flame, Sun, TreePine } from "lucide-react"
+import { ChevronLeft, ChevronRight, Flame, Sun, TreePine, X } from "lucide-react"
 
 interface TaskItem {
   id: string
   text: string
   numerator: number
   denominator: number
+  days?: number
 }
 
 interface Table {
@@ -30,6 +31,8 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
   const [currentTableIndex, setCurrentTableIndex] = useState(0)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editText, setEditText] = useState("")
+  const [editingDaysId, setEditingDaysId] = useState<string | null>(null)
+  const [editDaysValue, setEditDaysValue] = useState("")
   const [isTransitioning, setIsTransitioning] = useState(false)
   const [showAverageLine, setShowAverageLine] = useState(false)
   const [hoveredTaskId, setHoveredTaskId] = useState<string | null>(null)
@@ -107,41 +110,70 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
         { id: "6", text: "Poo", numerator: 0, denominator: initialData.find((d) => d.name === "Poo")?.count || 1 },
       ],
     },
+    {
+      title: "Importantes",
+      tasks: [],
+    },
   ])
 
   const loadProgressFromDatabase = async () => {
     try {
-      setIsLoading(true)
-      const response = await fetch("/api/progress")
+      const response = await fetch("/api/progress", { cache: "no-store" })
       if (response.ok) {
         const progressData = await response.json()
 
         // Actualizar las tablas con el progreso guardado
-        const updatedTables = tables.map((table) => ({
-          ...table,
-          tasks: table.tasks.map((task) => {
-            const tableType = table.title === "Teoría" ? "theory" : "practice"
-            const savedProgress = progressData.find(
-              (p: any) => p.subject_name === task.text && p.table_type === tableType,
-            )
+        setTables((prev) =>
+          prev.map((table) => ({
+            ...table,
+            tasks: table.tasks.map((task) => {
+              const tableType = table.title === "Teoría" ? "theory" : "practice"
+              const savedProgress = progressData.find(
+                (p: any) => p.subject_name === task.text && p.table_type === tableType,
+              )
 
-            if (savedProgress) {
-              return {
-                ...task,
-                numerator: savedProgress.current_progress,
-                denominator: savedProgress.total_pdfs,
+              if (savedProgress) {
+                return {
+                  ...task,
+                  numerator: savedProgress.current_progress,
+                  denominator: savedProgress.total_pdfs,
+                }
               }
-            }
-            return task
-          }),
-        }))
-
-        setTables(updatedTables)
+              return task
+            }),
+          })),
+        )
       }
     } catch (error) {
       console.error("Error loading progress:", error)
-    } finally {
-      setIsLoading(false)
+    }
+  }
+
+  const loadImportantFromDatabase = async () => {
+    try {
+      const response = await fetch("/api/important", { cache: "no-store" })
+      if (response.ok) {
+        const tasks = await response.json()
+        setTables((prev) => {
+          const newTables = [...prev]
+          const index = newTables.findIndex((t) => t.title === "Importantes")
+          if (index !== -1) {
+            newTables[index] = {
+              ...newTables[index],
+              tasks: tasks.map((t: any) => ({
+                id: String(t.id),
+                text: t.text,
+                numerator: t.numerator,
+                denominator: t.denominator,
+                days: t.days_remaining,
+              })),
+            }
+          }
+          return newTables
+        })
+      }
+    } catch (error) {
+      console.error("Error loading important tasks:", error)
     }
   }
 
@@ -185,19 +217,36 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
   }, [])
 
   useEffect(() => {
-    loadProgressFromDatabase()
+    setIsLoading(true)
+    Promise.all([loadProgressFromDatabase(), loadImportantFromDatabase()])
+      .finally(() => setIsLoading(false))
   }, [])
 
   const currentTable = tables[currentTableIndex]
 
-  const saveTask = (id: string) => {
+  const saveTask = async (id: string) => {
     const newTables = [...tables]
     newTables[currentTableIndex].tasks = newTables[currentTableIndex].tasks.map((task) =>
       task.id === id ? { ...task, text: editText } : task,
     )
     setTables(newTables)
+    const updatedTask = newTables[currentTableIndex].tasks.find((t) => t.id === id)
     setEditingId(null)
     setEditText("")
+
+    if (currentTable.title === "Importantes" && updatedTask) {
+      await fetch("/api/important", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: Number(updatedTask.id),
+          text: updatedTask.text,
+          numerator: updatedTask.numerator,
+          denominator: updatedTask.denominator,
+          days_remaining: updatedTask.days || 0,
+        }),
+      })
+    }
   }
 
   const updateProgress = async (id: string, numerator: number, denominator: number) => {
@@ -208,8 +257,21 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
       const task = newTables[currentTableIndex].tasks[taskIndex]
       newTables[currentTableIndex].tasks[taskIndex] = { ...task, numerator, denominator }
       setTables(newTables)
-
-      await saveProgressToDatabase(task.text, currentTable.title as "Teoría" | "Práctica", numerator, denominator)
+      if (currentTable.title === "Importantes") {
+        await fetch("/api/important", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            id: Number(task.id),
+            text: task.text,
+            numerator,
+            denominator,
+            days_remaining: task.days || 0,
+          }),
+        })
+      } else {
+        await saveProgressToDatabase(task.text, currentTable.title as "Teoría" | "Práctica", numerator, denominator)
+      }
     }
   }
 
@@ -259,6 +321,68 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
     }
 
     return pdfsNeeded
+  }
+
+  const updateDays = async (id: string, days: number) => {
+    const newTables = [...tables]
+    const taskIndex = newTables[currentTableIndex].tasks.findIndex((task) => task.id === id)
+    if (taskIndex !== -1) {
+      const task = newTables[currentTableIndex].tasks[taskIndex]
+      newTables[currentTableIndex].tasks[taskIndex] = { ...task, days }
+      setTables(newTables)
+      await fetch("/api/important", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: Number(task.id),
+          text: task.text,
+          numerator: task.numerator,
+          denominator: task.denominator,
+          days_remaining: days,
+        }),
+      })
+    }
+  }
+
+  const addImportantTask = async () => {
+    const response = await fetch("/api/important", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    })
+    if (response.ok) {
+      const task = await response.json()
+      setTables((prev) => {
+        const newTables = [...prev]
+        const index = newTables.findIndex((t) => t.title === "Importantes")
+        if (index !== -1) {
+          newTables[index].tasks.push({
+            id: String(task.id),
+            text: task.text,
+            numerator: task.numerator,
+            denominator: task.denominator,
+            days: task.days_remaining,
+          })
+        }
+        return newTables
+      })
+    }
+  }
+
+  const removeImportantTask = async (id: string) => {
+    await fetch("/api/important", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: Number(id) }),
+    })
+    setTables((prev) => {
+      const newTables = [...prev]
+      const index = newTables.findIndex((t) => t.title === "Importantes")
+      if (index !== -1) {
+        newTables[index].tasks = newTables[index].tasks.filter((t) => t.id !== id)
+      }
+      return newTables
+    })
   }
 
   const goToPreviousTable = () => {
@@ -312,6 +436,17 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
 
   return (
     <div className="min-h-screen bg-background p-6 relative">
+      <div className="fixed top-6 left-6 z-30">
+        <Button
+          onClick={() =>
+            setCurrentTableIndex(tables.findIndex((t) => t.title === "Importantes"))
+          }
+          className="w-16 h-16 rounded-full bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
+          size="lg"
+        >
+          <span className="text-xs text-white font-bold">IMP</span>
+        </Button>
+      </div>
       <div className="fixed top-6 right-6 z-30">
         <Button
           onClick={() => setShowAverageLine(!showAverageLine)}
@@ -336,7 +471,10 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
           className={`space-y-3 transition-all duration-300 ${isTransitioning ? "opacity-0 transform translate-x-4" : "opacity-100 transform translate-x-0"}`}
         >
           {currentTable.tasks.map((task) => {
-            const daysRemaining = calculateDaysRemaining(task.text, currentTable.title as "Teoría" | "Práctica")
+            const daysRemaining =
+              currentTable.title === "Importantes"
+                ? task.days || 0
+                : calculateDaysRemaining(task.text, currentTable.title as "Teoría" | "Práctica")
             const { icon: IconComponent, bgColor, iconColor } = getIconAndColor(daysRemaining)
             const currentPercentage = getProgressPercentage(task.numerator, task.denominator)
             const averagePercentage = calculateAveragePercentage()
@@ -353,9 +491,33 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
               >
                 <div
                   className={`absolute top-0 right-0 z-20 flex items-center gap-1 bg-gradient-to-r ${bgColor} text-white px-2 py-1 rounded-bl-lg text-xs font-bold shadow-lg`}
+                  onClick={() => {
+                    if (currentTable.title === "Importantes") {
+                      setEditingDaysId(task.id)
+                      setEditDaysValue(String(task.days || 0))
+                    }
+                  }}
                 >
                   <IconComponent className={`h-3 w-3 ${iconColor}`} />
-                  <span>{daysRemaining}d</span>
+                  {currentTable.title === "Importantes" && editingDaysId === task.id ? (
+                    <Input
+                      value={editDaysValue}
+                      onChange={(e) => setEditDaysValue(e.target.value)}
+                      onBlur={() => {
+                        updateDays(task.id, Number.parseInt(editDaysValue) || 0)
+                        setEditingDaysId(null)
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          updateDays(task.id, Number.parseInt(editDaysValue) || 0)
+                          setEditingDaysId(null)
+                        }
+                      }}
+                      className="w-10 h-4 text-black text-center bg-white rounded"
+                    />
+                  ) : (
+                    <span>{daysRemaining}d</span>
+                  )}
                 </div>
 
                 <div
@@ -436,11 +598,29 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
                   <div className="text-sm text-muted-foreground font-medium shrink-0 w-12 text-right">
                     {Math.round(getProgressPercentage(task.numerator, task.denominator))}%
                   </div>
+                  {currentTable.title === "Importantes" && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="ml-2 bg-transparent"
+                      onClick={() => removeImportantTask(task.id)}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  )}
                 </div>
               </div>
             )
           })}
         </div>
+
+        {currentTable.title === "Importantes" && (
+          <div className="flex justify-center mt-8">
+            <Button onClick={addImportantTask} className="bg-blue-500 hover:bg-blue-600">
+              Agregar
+            </Button>
+          </div>
+        )}
 
         <div className="flex justify-center gap-4 mt-8">
           <Button onClick={goToPreviousTable} variant="outline" size="lg" className="w-16 h-16 bg-transparent">

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -2,6 +2,20 @@ import { neon } from "@neondatabase/serverless"
 
 const sql = neon(process.env.DATABASE_URL!)
 
+async function ensureImportantTasksTable() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS important_tasks (
+      id SERIAL PRIMARY KEY,
+      text TEXT NOT NULL,
+      numerator INTEGER DEFAULT 0,
+      denominator INTEGER DEFAULT 1,
+      days_remaining INTEGER DEFAULT 0,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+  `
+}
+
 export interface Subject {
   id: number
   name: string
@@ -18,6 +32,16 @@ export interface Progress {
   table_type: "theory" | "practice"
   current_progress: number
   total_pdfs: number
+  created_at: string
+  updated_at: string
+}
+
+export interface ImportantTask {
+  id: number
+  text: string
+  numerator: number
+  denominator: number
+  days_remaining: number
   created_at: string
   updated_at: string
 }
@@ -67,10 +91,73 @@ export async function updateProgress(
   totalPdfs: number,
 ) {
   await sql`
-    UPDATE progress 
-    SET current_progress = ${currentProgress}, 
+    UPDATE progress
+    SET current_progress = ${currentProgress},
         total_pdfs = ${totalPdfs},
         updated_at = CURRENT_TIMESTAMP
     WHERE subject_name = ${subjectName} AND table_type = ${tableType}
   `
+}
+
+export async function getImportantTasks(): Promise<ImportantTask[]> {
+  await ensureImportantTasksTable()
+  const result = await sql`SELECT * FROM important_tasks ORDER BY id`
+  return result as ImportantTask[]
+}
+
+export async function createImportantTask(
+  data: Partial<ImportantTask>,
+): Promise<ImportantTask> {
+  await ensureImportantTasksTable()
+  const result = await sql<ImportantTask[]>`
+    INSERT INTO important_tasks (text, numerator, denominator, days_remaining)
+    VALUES (
+      ${data.text ?? ""},
+      ${data.numerator ?? 0},
+      ${data.denominator ?? 1},
+      ${data.days_remaining ?? 0}
+    )
+    RETURNING *
+  `
+  return result[0]
+}
+
+export async function updateImportantTask(
+  id: number,
+  data: Partial<ImportantTask>,
+): Promise<ImportantTask | null> {
+  const updates = []
+  const values: any[] = []
+  let paramIndex = 1
+
+  if (data.text !== undefined) {
+    updates.push(`text = $${paramIndex++}`)
+    values.push(data.text)
+  }
+  if (data.numerator !== undefined) {
+    updates.push(`numerator = $${paramIndex++}`)
+    values.push(data.numerator)
+  }
+  if (data.denominator !== undefined) {
+    updates.push(`denominator = $${paramIndex++}`)
+    values.push(data.denominator)
+  }
+  if (data.days_remaining !== undefined) {
+    updates.push(`days_remaining = $${paramIndex++}`)
+    values.push(data.days_remaining)
+  }
+
+  if (updates.length === 0) return null
+
+  const query = `UPDATE important_tasks SET ${updates.join(", ")}, updated_at = CURRENT_TIMESTAMP WHERE id = $${paramIndex} RETURNING *`
+  values.push(id)
+
+  await ensureImportantTasksTable()
+  const result = await sql<ImportantTask[]>(query, values)
+  return result[0] ?? null
+}
+
+export async function deleteImportantTask(id: number): Promise<void> {
+  await ensureImportantTasksTable()
+  await sql`DELETE FROM important_tasks WHERE id = ${id}`
 }

--- a/scripts/04-create-important-tasks-table.sql
+++ b/scripts/04-create-important-tasks-table.sql
@@ -1,0 +1,10 @@
+-- Creating table for important tasks
+CREATE TABLE IF NOT EXISTS important_tasks (
+  id SERIAL PRIMARY KEY,
+  text TEXT NOT NULL,
+  numerator INTEGER DEFAULT 0,
+  denominator INTEGER DEFAULT 1,
+  days_remaining INTEGER DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- Add new `important_tasks` database helpers and API route for CRUD operations
- Extend progress tracker with left-side button and full UI to manage "Importantes" tasks including days editor
- Create `important_tasks` table automatically and add SQL migration script
- Ensure important task API returns created/updated rows and disable route caching
- Avoid cached fetches and update UI after creating new important tasks
- Fix race condition when loading important tasks so existing items appear on initial view

## Testing
- `pnpm lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4152ea4883308a6016f552699569