### PR TITLE
Automatically decrement important task days

### DIFF
--- a/app/api/important/route.ts
+++ b/app/api/important/route.ts
@@ -11,7 +11,38 @@ export const dynamic = "force-dynamic"
 export async function GET() {
   try {
     const tasks = await getImportantTasks()
-    return NextResponse.json(tasks)
+    const today = new Date()
+
+    const updatedTasks = await Promise.all(
+      tasks.map(async (task) => {
+        const lastUpdate = new Date(task.updated_at)
+        const diffTime = today.getTime() - lastUpdate.getTime()
+        const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
+
+        if (diffDays > 0) {
+          const newDaysRemaining = Math.max(task.days_remaining - diffDays, 0)
+          const newNumerator = Math.min(
+            task.denominator,
+            task.denominator - newDaysRemaining,
+          )
+          const updated = await updateImportantTask(task.id, {
+            days_remaining: newDaysRemaining,
+            numerator: newNumerator,
+          })
+          return (
+            updated ?? {
+              ...task,
+              days_remaining: newDaysRemaining,
+              numerator: newNumerator,
+            }
+          )
+        }
+
+        return task
+      }),
+    )
+
+    return NextResponse.json(updatedTasks)
   } catch (error) {
     console.error("Error fetching important tasks:", error)
     return NextResponse.json({ error: "Failed to fetch" }, { status: 500 })


### PR DESCRIPTION
## Summary
- Automatically lower `days_remaining` for important tasks based on last update
- Persist new values and return updated tasks from API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive setup required)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5d3d2f8483308311e1ae3952c2bd