### PR TITLE
fix: sync daily progress and preserve important task fields

### DIFF
--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -4,7 +4,30 @@ import { getProgress, updateProgress } from "@/lib/database"
 export async function GET() {
   try {
     const progress = await getProgress()
-    return NextResponse.json(progress)
+    const today = new Date()
+
+    const updatedProgress = await Promise.all(
+      progress.map(async (task) => {
+        const lastUpdate = new Date(task.updated_at)
+        const diffTime = today.getTime() - lastUpdate.getTime()
+        const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
+
+        if (diffDays > 0) {
+          const newProgress = task.current_progress + diffDays
+          await updateProgress(
+            task.subject_name,
+            task.table_type,
+            newProgress,
+            task.total_pdfs,
+          )
+          return { ...task, current_progress: newProgress }
+        }
+
+        return task
+      }),
+    )
+
+    return NextResponse.json(updatedProgress)
   } catch (error) {
     console.error("Error fetching progress:", error)
     return NextResponse.json({ error: "Failed to fetch progress" }, { status: 500 })


### PR DESCRIPTION
## Summary
- prevent overwriting important task fields when updating partial data
- auto-increment theory and practice progress based on days elapsed

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: No database connection string was provided to `neon()`)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0f73445483309b6165b0eec1664a