### PR TITLE
Fix automatic day decrement and progress update

### DIFF
--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -4,7 +4,33 @@ import { getProgress, updateProgress } from "@/lib/database"
 export async function GET() {
   try {
     const progress = await getProgress()
-    return NextResponse.json(progress)
+    const today = new Date()
+
+    const updatedProgress = await Promise.all(
+      progress.map(async (p) => {
+        const lastUpdate = new Date(p.updated_at)
+        const diffTime = today.getTime() - lastUpdate.getTime()
+        const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
+
+        if (diffDays > 0) {
+          const newProgress = Math.min(
+            p.current_progress + diffDays,
+            p.total_pdfs,
+          )
+          await updateProgress(
+            p.subject_name,
+            p.table_type,
+            newProgress,
+            p.total_pdfs,
+          )
+          return { ...p, current_progress: newProgress }
+        }
+
+        return p
+      }),
+    )
+
+    return NextResponse.json(updatedProgress)
   } catch (error) {
     console.error("Error fetching progress:", error)
     return NextResponse.json({ error: "Failed to fetch progress" }, { status: 500 })

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -129,10 +129,10 @@ export async function updateImportantTask(
   await ensureImportantTasksTable()
   const result = await sql<ImportantTask[]>`
     UPDATE important_tasks
-    SET text = ${data.text ?? ""},
-        numerator = ${data.numerator ?? 0},
-        denominator = ${data.denominator ?? 1},
-        days_remaining = ${data.days_remaining ?? 0},
+    SET text = COALESCE(${data.text}, text),
+        numerator = COALESCE(${data.numerator}, numerator),
+        denominator = COALESCE(${data.denominator}, denominator),
+        days_remaining = COALESCE(${data.days_remaining}, days_remaining),
         updated_at = CURRENT_TIMESTAMP
     WHERE id = ${id}
     RETURNING *


### PR DESCRIPTION
## Summary
- Fix important task updates to avoid resetting untouched fields
- Auto-increment theory and practice progress based on days passed

## Testing
- `pnpm lint` *(fails: configuration prompt for ESLint)*
- `pnpm build` *(fails: no database connection string provided)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0f73445483309b6165b0eec1664a