### PR TITLE
feat: add calendar view and ensure important table

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -16,6 +16,13 @@ async function ensureImportantTasksTable() {
   `
 }
 
+// Ensure the table exists when the module is loaded so important tasks persist
+if (process.env.DATABASE_URL) {
+  ensureImportantTasksTable().catch((e) =>
+    console.error("Error ensuring important_tasks table", e),
+  )
+}
+
 export interface Subject {
   id: number
   name: string


### PR DESCRIPTION
## Summary
- ensure the important_tasks table is created on module load to avoid accidental removal
- add full-screen calendar view toggled with `c`, with arrow navigation and color-coded task markers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c08281dbd883308913de9f154b1b9a