### PR TITLE
Add calendar view and improve important tasks

### DIFF
--- a/app/api/important/route.ts
+++ b/app/api/important/route.ts
@@ -11,38 +11,7 @@ export const dynamic = "force-dynamic"
 export async function GET() {
   try {
     const tasks = await getImportantTasks()
-    const today = new Date()
-
-    const updatedTasks = await Promise.all(
-      tasks.map(async (task) => {
-        const lastUpdate = new Date(task.updated_at)
-        const diffTime = today.getTime() - lastUpdate.getTime()
-        const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
-
-        if (diffDays > 0) {
-          const newDaysRemaining = Math.max(task.days_remaining - diffDays, 0)
-          const newNumerator = Math.min(
-            task.denominator,
-            task.denominator - newDaysRemaining,
-          )
-          const updated = await updateImportantTask(task.id, {
-            days_remaining: newDaysRemaining,
-            numerator: newNumerator,
-          })
-          return (
-            updated ?? {
-              ...task,
-              days_remaining: newDaysRemaining,
-              numerator: newNumerator,
-            }
-          )
-        }
-
-        return task
-      }),
-    )
-
-    return NextResponse.json(updatedTasks)
+    return NextResponse.json(tasks)
   } catch (error) {
     console.error("Error fetching important tasks:", error)
     return NextResponse.json({ error: "Failed to fetch" }, { status: 500 })

--- a/components/progress-tracker.tsx
+++ b/components/progress-tracker.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ChevronLeft, ChevronRight, Flame, Sun, TreePine, X } from "lucide-react"
@@ -46,6 +46,8 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
   >([])
   const [eventIndex, setEventIndex] = useState(0)
   const [eventZoom, setEventZoom] = useState(2)
+  const [isCalendarMode, setIsCalendarMode] = useState(false)
+  const [calendarDate, setCalendarDate] = useState(new Date())
 
   useEffect(() => {
     const stored = localStorage.getItem("eventZoom")
@@ -119,6 +121,41 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
       tasks: [],
     },
   ])
+
+  const calendarEvents = useMemo(() => {
+    const events: { date: Date; label: string; color: string }[] = []
+    initialData.forEach((subject) => {
+      if (subject.theoryDate) {
+        events.push({
+          date: new Date(subject.theoryDate),
+          label: `${subject.name} teoría`,
+          color: "bg-blue-500",
+        })
+      }
+      if (subject.practiceDate) {
+        events.push({
+          date: new Date(subject.practiceDate),
+          label: `${subject.name} práctica`,
+          color: "bg-green-500",
+        })
+      }
+    })
+    const today = new Date()
+    tables
+      .find((t) => t.title === "Importantes")
+      ?.tasks.forEach((task) => {
+        if (task.days !== undefined && task.days >= 0) {
+          const due = new Date(today)
+          due.setDate(due.getDate() + (task.days || 0))
+          events.push({
+            date: due,
+            label: task.text,
+            color: "bg-orange-500",
+          })
+        }
+      })
+    return events
+  }, [tables, initialData])
 
   const saveTopicsToLocalStorage = (tables: Table[]) => {
     const topicsData: Record<string, string[]> = {}
@@ -248,6 +285,25 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === "c" && !editingId && !editingDaysId) {
+        event.preventDefault()
+        setIsCalendarMode((prev) => !prev)
+        return
+      }
+      if (isCalendarMode) {
+        if (event.key === "ArrowRight") {
+          event.preventDefault()
+          setCalendarDate(
+            (prev) => new Date(prev.getFullYear(), prev.getMonth() + 1, 1),
+          )
+        } else if (event.key === "ArrowLeft") {
+          event.preventDefault()
+          setCalendarDate(
+            (prev) => new Date(prev.getFullYear(), prev.getMonth() - 1, 1),
+          )
+        }
+        return
+      }
       if (event.key.toLowerCase() === "i" && !editingId && !editingDaysId) {
         event.preventDefault()
         if (isEventMode) {
@@ -308,7 +364,7 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
 
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [isEventMode, editingId, editingDaysId, tables, eventTasks])
+  }, [isEventMode, editingId, editingDaysId, tables, eventTasks, isCalendarMode])
 
   useEffect(() => {
     const fetchData = async () => {
@@ -551,6 +607,41 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
     }
   }
 
+  const renderCalendarCells = () => {
+    const year = calendarDate.getFullYear()
+    const month = calendarDate.getMonth()
+    const daysInMonth = new Date(year, month + 1, 0).getDate()
+    const startDay = new Date(year, month, 1).getDay()
+    const cells = []
+    for (let i = 0; i < startDay; i++) {
+      cells.push(<div key={`empty-${i}`} />)
+    }
+    for (let day = 1; day <= daysInMonth; day++) {
+      const dayEvents = calendarEvents.filter(
+        (e) =>
+          e.date.getFullYear() === year &&
+          e.date.getMonth() === month &&
+          e.date.getDate() === day,
+      )
+      cells.push(
+        <div key={day} className="border h-24 p-1 overflow-hidden">
+          <div className="text-[10px] font-bold">{day}</div>
+          <div className="space-y-1 mt-1">
+            {dayEvents.map((ev, idx) => (
+              <div
+                key={idx}
+                className={`text-[9px] text-white px-1 rounded ${ev.color}`}
+              >
+                {ev.label}
+              </div>
+            ))}
+          </div>
+        </div>,
+      )
+    }
+    return cells
+  }
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
@@ -562,7 +653,52 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
     )
   }
 
-if (isEventMode && eventTasks.length > 0) {
+  if (isCalendarMode) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="bg-card p-4 rounded-lg shadow-lg w-full max-w-3xl">
+          <div className="flex items-center justify-between mb-4">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() =>
+                setCalendarDate(
+                  (prev) => new Date(prev.getFullYear(), prev.getMonth() - 1, 1),
+                )
+              }
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <h2 className="text-xl font-bold capitalize">
+              {calendarDate.toLocaleString("es-ES", { month: "long" })}{" "}
+              {calendarDate.getFullYear()}
+            </h2>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() =>
+                setCalendarDate(
+                  (prev) => new Date(prev.getFullYear(), prev.getMonth() + 1, 1),
+                )
+              }
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="grid grid-cols-7 gap-2 text-xs text-center mb-2">
+            {["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"].map((d) => (
+              <div key={d} className="font-semibold">
+                {d}
+              </div>
+            ))}
+            {renderCalendarCells()}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (isEventMode && eventTasks.length > 0) {
     const current = eventTasks[eventIndex]
     const { task, tableTitle, daysRemaining } = current
     const { icon: IconComponent, bgColor, iconColor } = getIconAndColor(daysRemaining)

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -101,8 +101,35 @@ export async function updateProgress(
 
 export async function getImportantTasks(): Promise<ImportantTask[]> {
   await ensureImportantTasksTable()
-  const result = await sql`SELECT * FROM important_tasks ORDER BY id`
-  return result as ImportantTask[]
+  const tasks = await sql<ImportantTask[]>`SELECT * FROM important_tasks ORDER BY id`
+  const today = new Date()
+  const updatedTasks = await Promise.all(
+    tasks.map(async (task) => {
+      const lastUpdate = new Date(task.updated_at)
+      const diffTime = today.getTime() - lastUpdate.getTime()
+      const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
+      if (diffDays > 0) {
+        const newDaysRemaining = Math.max(task.days_remaining - diffDays, 0)
+        const newNumerator = Math.min(
+          task.denominator,
+          task.denominator - newDaysRemaining,
+        )
+        const updated = await updateImportantTask(task.id, {
+          days_remaining: newDaysRemaining,
+          numerator: newNumerator,
+        })
+        return (
+          updated ?? {
+            ...task,
+            days_remaining: newDaysRemaining,
+            numerator: newNumerator,
+          }
+        )
+      }
+      return task
+    }),
+  )
+  return updatedTasks
 }
 
 export async function createImportantTask(


### PR DESCRIPTION
## Summary
- Decrement important task deadlines on fetch and simplify API route
- Add keyboard-driven calendar with monthly navigation and color-coded events

## Testing
- `pnpm lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c08281dbd883308913de9f154b1b9a