### PR TITLE
Add calendar view and improve important tasks

### DIFF
--- a/app/api/important/route.ts
+++ b/app/api/important/route.ts
@@ -11,38 +11,7 @@ export const dynamic = "force-dynamic"
 export async function GET() {
   try {
     const tasks = await getImportantTasks()
-    const today = new Date()
-
-    const updatedTasks = await Promise.all(
-      tasks.map(async (task) => {
-        const lastUpdate = new Date(task.updated_at)
-        const diffTime = today.getTime() - lastUpdate.getTime()
-        const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
-
-        if (diffDays > 0) {
-          const newDaysRemaining = Math.max(task.days_remaining - diffDays, 0)
-          const newNumerator = Math.min(
-            task.denominator,
-            task.denominator - newDaysRemaining,
-          )
-          const updated = await updateImportantTask(task.id, {
-            days_remaining: newDaysRemaining,
-            numerator: newNumerator,
-          })
-          return (
-            updated ?? {
-              ...task,
-              days_remaining: newDaysRemaining,
-              numerator: newNumerator,
-            }
-          )
-        }
-
-        return task
-      }),
-    )
-
-    return NextResponse.json(updatedTasks)
+    return NextResponse.json(tasks)
   } catch (error) {
     console.error("Error fetching important tasks:", error)
     return NextResponse.json({ error: "Failed to fetch" }, { status: 500 })

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -16,6 +16,11 @@ async function ensureImportantTasksTable() {
   `
 }
 
+// Ensure the important_tasks table exists as soon as the module is loaded
+ensureImportantTasksTable().catch((err) =>
+  console.error("Failed to ensure important_tasks table:", err),
+)
+
 export interface Subject {
   id: number
   name: string
@@ -101,8 +106,35 @@ export async function updateProgress(
 
 export async function getImportantTasks(): Promise<ImportantTask[]> {
   await ensureImportantTasksTable()
-  const result = await sql`SELECT * FROM important_tasks ORDER BY id`
-  return result as ImportantTask[]
+  const tasks = await sql<ImportantTask[]>`SELECT * FROM important_tasks ORDER BY id`
+  const today = new Date()
+  const updatedTasks = await Promise.all(
+    tasks.map(async (task) => {
+      const lastUpdate = new Date(task.updated_at)
+      const diffTime = today.getTime() - lastUpdate.getTime()
+      const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
+      if (diffDays > 0) {
+        const newDaysRemaining = Math.max(task.days_remaining - diffDays, 0)
+        const newNumerator = Math.min(
+          task.denominator,
+          task.denominator - newDaysRemaining,
+        )
+        const updated = await updateImportantTask(task.id, {
+          days_remaining: newDaysRemaining,
+          numerator: newNumerator,
+        })
+        return (
+          updated ?? {
+            ...task,
+            days_remaining: newDaysRemaining,
+            numerator: newNumerator,
+          }
+        )
+      }
+      return task
+    }),
+  )
+  return updatedTasks
 }
 
 export async function createImportantTask(


### PR DESCRIPTION
## Summary
- Show remaining items for theory, practice and important tasks in calendar view
- Highlight the current day in the calendar
- Initialize important task table on module load to maintain persistence

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68c08281dbd883308913de9f154b1b9a