### PR TITLE
Fix countdown persistence and enforce weekly cycles

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -96,11 +96,25 @@ export async function updateProgress(
   totalPdfs: number,
 ) {
   await sql`
-    UPDATE progress
-    SET current_progress = ${currentProgress},
-        total_pdfs = ${totalPdfs},
-        updated_at = CURRENT_TIMESTAMP
-    WHERE subject_name = ${subjectName} AND table_type = ${tableType}
+    INSERT INTO progress (
+      subject_name,
+      table_type,
+      current_progress,
+      total_pdfs,
+      updated_at
+    )
+    VALUES (
+      ${subjectName},
+      ${tableType},
+      ${currentProgress},
+      ${totalPdfs},
+      CURRENT_TIMESTAMP
+    )
+    ON CONFLICT (subject_name, table_type)
+    DO UPDATE SET
+      current_progress = EXCLUDED.current_progress,
+      total_pdfs = EXCLUDED.total_pdfs,
+      updated_at = CURRENT_TIMESTAMP
   `
 }
 


### PR DESCRIPTION
## Summary
- keep theory and practice countdowns on a minimum 7-day cycle while syncing saved totals when calendar dates change
- upsert progress records so updated days/denominators persist in the database
- add a minimal Next.js ESLint configuration to support linting

## Testing
- `pnpm lint` *(fails: ESLint package is not installed in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a472c7048330be537730eccc3764