### PR TITLE
Fix Neon query usage for updates

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -81,7 +81,7 @@ export async function updateSubject(name: string, data: Partial<Subject>) {
   const query = `UPDATE subjects SET ${updates.join(", ")} WHERE name = $${paramIndex}`
   values.push(name)
 
-  await sql(query, values)
+  await sql.query(query, values)
 }
 
 export async function getProgress(): Promise<Progress[]> {
@@ -187,7 +187,7 @@ export async function updateImportantTask(
   const query = `UPDATE important_tasks SET ${updates.join(", ")} WHERE id = $${paramIndex} RETURNING *`
   values.push(id)
 
-  const result = await sql<ImportantTask[]>(query, values)
+  const result = (await sql.query(query, values)) as ImportantTask[]
   return result[0] ?? null
 }
 


### PR DESCRIPTION
## Summary
- use `sql.query` for parameterized update statements in the Neon client
- ensure important task updates return typed results after the query fix

## Testing
- pnpm lint *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c93d0e207c8330bed404109805c042