### PR TITLE
Fix date parsing to avoid calendar day offsets

### DIFF
--- a/components/progress-tracker.tsx
+++ b/components/progress-tracker.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ChevronLeft, ChevronRight, Flame, Sun, TreePine, X } from "lucide-react"
 
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
 const parseDateInput = (input?: string): Date | null => {
   if (!input) return null
   if (/^\d+d$/.test(input)) {
@@ -12,6 +14,12 @@ const parseDateInput = (input?: string): Date | null => {
     const date = new Date()
     date.setDate(date.getDate() + days)
     return date
+  }
+  if (DATE_ONLY_PATTERN.test(input)) {
+    const [year, month, day] = input.split("-").map((part) => Number(part))
+    if (!Number.isNaN(year) && !Number.isNaN(month) && !Number.isNaN(day)) {
+      return new Date(year, month - 1, day)
+    }
   }
   const date = new Date(input)
   return isNaN(date.getTime()) ? null : date
@@ -885,6 +893,7 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
 
     if (targetTable.title === "Teoría" || targetTable.title === "Práctica") {
       const isoDate = normalizedSelected.toISOString()
+      const dateOnly = isoDate.split("T")[0]
       const tableTitle = targetTable.title
 
       setSubjectSchedules((prev) =>
@@ -894,9 +903,9 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
           }
           return {
             ...subject,
-            theoryDate: tableTitle === "Teoría" ? isoDate : subject.theoryDate,
+            theoryDate: tableTitle === "Teoría" ? dateOnly : subject.theoryDate,
             practiceDate:
-              tableTitle === "Práctica" ? isoDate : subject.practiceDate,
+              tableTitle === "Práctica" ? dateOnly : subject.practiceDate,
             theoryTotal:
               tableTitle === "Teoría"
                 ? Math.max(diffDays, 1)
@@ -911,9 +920,9 @@ export default function ProgressTracker({ initialData }: ProgressTrackerProps) {
 
       const payload: Record<string, unknown> = { name: task.text }
       if (tableTitle === "Teoría") {
-        payload.theory_date = isoDate
+        payload.theory_date = dateOnly
       } else {
-        payload.practice_date = isoDate
+        payload.practice_date = dateOnly
       }
 
       try {

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -81,7 +81,7 @@ export async function updateSubject(name: string, data: Partial<Subject>) {
   const query = `UPDATE subjects SET ${updates.join(", ")} WHERE name = $${paramIndex}`
   values.push(name)
 
-  await sql(query, values)
+  await sql.query(query, values)
 }
 
 export async function getProgress(): Promise<Progress[]> {
@@ -187,7 +187,7 @@ export async function updateImportantTask(
   const query = `UPDATE important_tasks SET ${updates.join(", ")} WHERE id = $${paramIndex} RETURNING *`
   values.push(id)
 
-  const result = await sql<ImportantTask[]>(query, values)
+  const result = (await sql.query(query, values)) as ImportantTask[]
   return result[0] ?? null
 }
 


### PR DESCRIPTION
## Summary
- treat YYYY-MM-DD strings as local dates when parsing calendar inputs to avoid timezone day shifts
- persist calendar selections as date-only strings when updating subject schedules and API payloads

## Testing
- pnpm lint *(fails: Next.js ESLint configuration prompt requires interactive input in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c93d0e207c8330bed404109805c042