### PR TITLE
Fix progress updates for canonical subject names

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -239,12 +239,18 @@ export async function updateProgress(
   totalPdfs: number,
 ) {
   const sql = getSql()
+  const canonical = canonicalSubjectName(subjectName)
+
+  // Ensure the canonical subject exists so the FK constraint is satisfied when inserting
+  await updateSubject(canonical, {})
+
   await sql`
-    UPDATE progress
-    SET current_progress = ${currentProgress},
-        total_pdfs = ${totalPdfs},
-        updated_at = CURRENT_TIMESTAMP
-    WHERE subject_name = ${subjectName} AND table_type = ${tableType}
+    INSERT INTO progress (subject_name, table_type, current_progress, total_pdfs)
+    VALUES (${canonical}, ${tableType}, ${currentProgress}, ${totalPdfs})
+    ON CONFLICT (subject_name, table_type) DO UPDATE SET
+      current_progress = EXCLUDED.current_progress,
+      total_pdfs = EXCLUDED.total_pdfs,
+      updated_at = CURRENT_TIMESTAMP
   `
 }
 


### PR DESCRIPTION
## Summary
- canonicalize subject names when updating progress rows
- ensure the subject exists before updating and upsert the progress entry so data is stored consistently

## Testing
- pnpm lint *(fails: requires interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d8246f8c833090246c9c22a3970a